### PR TITLE
Fix test imports and add CI PYTHONPATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
       - run: ruff check .
       - run: black --check .
       - run: isort --check-only .
-      - run: pytest
+      - run: PYTHONPATH=src pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+env/
+venv/
+ENV/
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# dotenv
+.env
+
+# MacOS
+.DS_Store

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -43,10 +43,13 @@ class TestPaperHunterAgent(unittest.TestCase):
         mock_paper.published.replace.return_value = Mock()
 
         # Mock datetime
-        with patch("src.paper_hunter_agent.datetime") as mock_datetime:
+        with patch("paper_hunter_agent.datetime") as mock_datetime:
             now = datetime.datetime(2024, 1, 2)
-            mock_datetime.now.return_value = now
             mock_paper.published.replace.return_value = now - datetime.timedelta(days=1)
+
+            mock_timedelta = Mock()
+            mock_timedelta.days = 1
+            mock_datetime.now.return_value.__sub__.return_value = mock_timedelta
 
             score = self.agent._calculate_relevance_score(mock_paper)
             self.assertGreaterEqual(score, 50)


### PR DESCRIPTION
## Summary
- ignore common Python artifacts
- ensure CI adds `src` to PYTHONPATH when running pytest
- adjust tests to patch `paper_hunter_agent.datetime`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c8781ee4c832f9b9a7dd5d9325cba