### PR TITLE
Harden network fetching and make demo offline with fixtures

### DIFF
--- a/fixtures/demo_papers.json
+++ b/fixtures/demo_papers.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Offline Demo: Surface-Code Logical Qubits with Biased Noise",
+    "authors": ["A. Demo", "B. Researcher"],
+    "arxiv_id": "2401.00001",
+    "doi": "10.1000/offline.demo.1",
+    "published": "2024-01-15",
+    "url_pdf": "fixtures/sample_paper_1.pdf",
+    "abstract": "We study quantum error correction in surface codes under biased noise and show improved logical error suppression using tailored decoding.",
+    "relevance_score": 93
+  },
+  {
+    "title": "Offline Demo: Fault-Tolerant Syndrome Extraction on NISQ Hardware",
+    "authors": ["C. Analyst", "D. Physicist"],
+    "arxiv_id": "2401.00002",
+    "doi": "10.1000/offline.demo.2",
+    "published": "2024-01-21",
+    "url_pdf": "fixtures/sample_paper_2.pdf",
+    "abstract": "This fixture paper evaluates hardware-efficient syndrome extraction routines and quantifies fidelity tradeoffs for near-term devices.",
+    "relevance_score": 88
+  },
+  {
+    "title": "Offline Demo: Decoder Benchmarks for Quantum Error Correction",
+    "authors": ["E. Engineer"],
+    "arxiv_id": "2401.00003",
+    "doi": "10.1000/offline.demo.3",
+    "published": "2024-01-24",
+    "url_pdf": "fixtures/sample_paper_3.pdf",
+    "abstract": "We benchmark matching-based and neural decoders on synthetic syndrome datasets and report practical deployment recommendations.",
+    "relevance_score": 84
+  }
+]

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import logging
 import sys
+from pathlib import Path
 
 from src.concept_map_agent import ConceptMapAgent
 from src.paper_hunter_agent import PaperHunterAgent
@@ -105,28 +106,19 @@ def demo_individual_agents():
     print("QUANTUM RESEARCH CHAIN - AGENT DEMONSTRATION")
     print("=" * 80)
 
-    # Demo PaperHunterAgent
+    # Demo PaperHunterAgent (offline fixture payload)
     print("\n1. PAPER HUNTER AGENT DEMO")
     print("-" * 40)
 
-    keywords = ["quantum error correction", "surface code"]
-    hunter = PaperHunterAgent(user_keywords=keywords)
-
-    # This will actually search arXiv - might take a moment
-    papers_json = hunter.hunt_papers(max_papers=3)
+    fixture_path = Path("fixtures/demo_papers.json")
+    papers_json = fixture_path.read_text(encoding="utf-8")
     print(papers_json)
 
     # Demo SummarizerAgent with sample data
     print("\n2. SUMMARIZER AGENT DEMO")
     print("-" * 40)
 
-    sample_paper = {
-        "title": "Quantum Error Correction with Surface Codes",
-        "authors": ["Alice Quantum", "Bob Physicist"],
-        "published": "2024-01-15",
-        "url_pdf": "https://arxiv.org/pdf/2401.00001.pdf",  # This is a placeholder
-        "abstract": "We present a comprehensive study of quantum error correction using surface codes. Our approach demonstrates improved error thresholds and practical implementation strategies for near-term quantum computers.",
-    }
+    sample_paper = json.loads(papers_json)[0]
 
     summarizer = SummarizerAgent()
     summary = summarizer.create_summary(sample_paper)

--- a/src/paper_hunter_agent.py
+++ b/src/paper_hunter_agent.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
@@ -36,6 +37,81 @@ class PaperHunterAgent:
         self.semantic_scholar_base_url = "https://api.semanticscholar.org/graph/v1"
         self.api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
         self.logger = logging.getLogger(__name__)
+        self.request_timeout_seconds = 15
+        self.request_max_retries = 3
+        self.request_backoff_seconds = 1
+
+    def _ensure_dependency(self, dependency: Any, package_name: str) -> bool:
+        """Return True when dependency is available, else log a clear error."""
+        if dependency is None:
+            self.logger.error(
+                "Missing dependency '%s'. Install it to enable this network path.",
+                package_name,
+            )
+            return False
+        return True
+
+    def _semantic_scholar_request(
+        self, url: str, params: Dict[str, Any], headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        """Request Semantic Scholar with timeout/retry/backoff and clear error taxonomy."""
+        if not self._ensure_dependency(requests, "requests"):
+            return {}
+
+        for attempt in range(1, self.request_max_retries + 1):
+            try:
+                response = requests.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    timeout=self.request_timeout_seconds,
+                )
+
+                if response.status_code == 200:
+                    return response.json()
+
+                if response.status_code == 429:
+                    self.logger.warning(
+                        "Semantic Scholar rate limited request (HTTP 429) on attempt %s/%s",
+                        attempt,
+                        self.request_max_retries,
+                    )
+                elif 500 <= response.status_code < 600:
+                    self.logger.warning(
+                        "Semantic Scholar upstream error (HTTP %s) on attempt %s/%s",
+                        response.status_code,
+                        attempt,
+                        self.request_max_retries,
+                    )
+                else:
+                    self.logger.error(
+                        "Semantic Scholar request failed with non-retriable status HTTP %s",
+                        response.status_code,
+                    )
+                    return {}
+
+            except requests.Timeout:
+                self.logger.warning(
+                    "Semantic Scholar timeout on attempt %s/%s",
+                    attempt,
+                    self.request_max_retries,
+                )
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "Semantic Scholar network error on attempt %s/%s: %s",
+                    attempt,
+                    self.request_max_retries,
+                    e,
+                )
+
+            if attempt < self.request_max_retries:
+                sleep_seconds = self.request_backoff_seconds * (2 ** (attempt - 1))
+                time.sleep(sleep_seconds)
+
+        self.logger.error(
+            "Semantic Scholar request exhausted retries (taxonomy: network_or_service_unavailable)"
+        )
+        return {}
 
     def search_arxiv_papers(self, days_back: int = 1) -> List[Dict[str, Any]]:
         """
@@ -47,8 +123,7 @@ class PaperHunterAgent:
         Returns:
             List of paper dictionaries
         """
-        if arxiv is None:
-            self.logger.error("arxiv package not available")
+        if not self._ensure_dependency(arxiv, "arxiv"):
             return []
 
         papers = []
@@ -113,6 +188,9 @@ class PaperHunterAgent:
         additional_papers = []
         cutoff_date = datetime.now() - timedelta(days=days_back)
 
+        if not self._ensure_dependency(requests, "requests"):
+            return additional_papers
+
         for arxiv_paper in arxiv_papers:
             try:
                 # Search for papers citing this arXiv paper
@@ -125,47 +203,45 @@ class PaperHunterAgent:
                 if self.api_key:
                     headers["x-api-key"] = self.api_key
 
-                response = requests.get(
-                    url,
-                    params={"fields": "title,authors,year,url,abstract,citationCount"},
+                data = self._semantic_scholar_request(
+                    url=url,
+                    params={
+                        "fields": "title,authors,year,url,abstract,citationCount,doi"
+                    },
                     headers=headers,
                 )
 
-                if response.status_code == 200:
-                    data = response.json()
-                    for citation in data.get("data", []):
-                        paper = citation.get("citingPaper", {})
+                for citation in data.get("data", []):
+                    paper = citation.get("citingPaper", {})
 
-                        # Basic filtering
-                        if not paper.get("title") or not paper.get("abstract"):
-                            continue
+                    # Basic filtering
+                    if not paper.get("title") or not paper.get("abstract"):
+                        continue
 
-                        # Check if recent enough (approximate)
-                        if paper.get("year") and paper["year"] < cutoff_date.year:
-                            continue
+                    # Check if recent enough (approximate)
+                    if paper.get("year") and paper["year"] < cutoff_date.year:
+                        continue
 
-                        # Check if matches keywords
-                        if not self._matches_keywords_text(
-                            paper.get("title", "") + " " + paper.get("abstract", "")
-                        ):
-                            continue
+                    # Check if matches keywords
+                    if not self._matches_keywords_text(
+                        paper.get("title", "") + " " + paper.get("abstract", "")
+                    ):
+                        continue
 
-                        paper_data = {
-                            "title": paper["title"],
-                            "authors": [
-                                author.get("name", "Unknown")
-                                for author in paper.get("authors", [])
-                            ],
-                            "arxiv_id": None,
-                            "doi": paper.get("doi"),
-                            "published": f"{paper.get('year', 'Unknown')}-01-01",  # Approximate
-                            "url_pdf": paper.get("url"),
-                            "abstract": paper.get("abstract", ""),
-                            "relevance_score": min(
-                                paper.get("citationCount", 0) * 5, 100
-                            ),
-                        }
-                        additional_papers.append(paper_data)
+                    paper_data = {
+                        "title": paper["title"],
+                        "authors": [
+                            author.get("name", "Unknown")
+                            for author in paper.get("authors", [])
+                        ],
+                        "arxiv_id": None,
+                        "doi": paper.get("doi"),
+                        "published": f"{paper.get('year', 'Unknown')}-01-01",  # Approximate
+                        "url_pdf": paper.get("url"),
+                        "abstract": paper.get("abstract", ""),
+                        "relevance_score": min(paper.get("citationCount", 0) * 5, 100),
+                    }
+                    additional_papers.append(paper_data)
 
             except Exception as e:
                 self.logger.error(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -52,6 +52,38 @@ class TestPaperHunterAgent(unittest.TestCase):
             self.assertGreaterEqual(score, 50)
             self.assertLessEqual(score, 100)
 
+    def test_search_semantic_scholar_dependency_guard(self):
+        """Semantic Scholar search returns empty list when requests is unavailable."""
+        with patch("paper_hunter_agent.requests", None):
+            results = self.agent.search_semantic_scholar(
+                arxiv_papers=[{"arxiv_id": "1234.56789"}], days_back=7
+            )
+        self.assertEqual(results, [])
+
+    def test_semantic_scholar_request_retries_then_succeeds(self):
+        """Semantic Scholar request retries transient failures with backoff."""
+        timeout_exc = self.agent.request_timeout_seconds
+        self.agent.request_timeout_seconds = 1
+
+        from paper_hunter_agent import requests as ph_requests
+
+        timeout_error = ph_requests.Timeout("timed out")
+        ok_response = Mock(status_code=200)
+        ok_response.json.return_value = {"data": []}
+
+        with patch("paper_hunter_agent.requests.get", side_effect=[timeout_error, ok_response]) as mock_get:
+            with patch("paper_hunter_agent.time.sleep") as mock_sleep:
+                data = self.agent._semantic_scholar_request(
+                    url="https://api.semanticscholar.org/graph/v1/paper/arXiv:1234/citations",
+                    params={"fields": "title"},
+                    headers={},
+                )
+
+        self.agent.request_timeout_seconds = timeout_exc
+        self.assertEqual(data, {"data": []})
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once()
+
 
 class TestSummarizerAgent(unittest.TestCase):
     """Test cases for SummarizerAgent."""


### PR DESCRIPTION
### Motivation
- Make networked codepaths fail fast with clear messages when optional dependencies are missing and avoid silent runtime errors.
- Improve resiliency of Semantic Scholar requests by adding timeouts, retries and backoff to handle transient network/service errors.
- Ensure the `--demo` flow is deterministic and fully offline so demonstrations don't require network access.

### Description
- Added dependency guard helper ` _ensure_dependency` and per-agent network settings (`request_timeout_seconds`, `request_max_retries`, `request_backoff_seconds`) in `PaperHunterAgent` (`src/paper_hunter_agent.py`).
- Introduced `_semantic_scholar_request` helper that performs `requests.get` with timeout, retry loop, exponential backoff and explicit logging for 429, 5xx, non-retriable statuses and retry exhaustion (`src/paper_hunter_agent.py`).
- Wired dependency checks into `search_arxiv_papers` and `search_semantic_scholar` so arXiv/Semantic Scholar paths return clean failures when dependencies are absent and the Semantic Scholar flow uses the resilient request helper (`src/paper_hunter_agent.py`).
- Switched demo mode to load a local fixture payload from `fixtures/demo_papers.json` and adjusted `main.py` to read that file for `--demo`, making the demo fully offline and deterministic (`main.py`, `fixtures/demo_papers.json`).
- Added unit tests to validate the dependency guard and retry behavior (`tests/test_agents.py`) and updated fixtures used by the demo.

### Testing
- Ran the full test suite with `python -m pytest -q`, which passed (16 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af9394154832f8180beac6348c731)