### PR TITLE
cli: return friendly message and no-op when summarizing empty papers list

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -41,6 +41,17 @@ def _parse_keywords(raw: str) -> list[str]:
     return [kw.strip() for kw in raw.split(",") if kw.strip()]
 
 
+def _summarize_empty_state_message(input_json: str) -> str:
+    """Build a friendly empty-state hint for summarize command."""
+    return "\n".join(
+        [
+            "📭 No papers found to summarize.",
+            f"Checked file: {input_json}",
+            'Next step: paperhunter hunt --keywords "quantum error correction" --output papers.json',
+        ]
+    )
+
+
 # ---------------------------------------------------------------------------
 # hunt
 # ---------------------------------------------------------------------------
@@ -85,6 +96,10 @@ def cmd_summarize(args: argparse.Namespace) -> int:
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         logger.error("Failed to read input JSON: %s", exc)
         return 1
+
+    if not papers:
+        logger.warning(_summarize_empty_state_message(args.input_json))
+        return 0
 
     summarizer = SummarizerAgent()
     summaries: list[str] = []


### PR DESCRIPTION
### Motivation
- Avoid confusing errors when the `summarize` command is given an empty papers JSON file by providing a clear hint and exiting successfully. 
- Give users a next-step suggestion so they know how to populate the input JSON. 
- Prevent unnecessary instantiation of the `SummarizerAgent` when there are no papers to process. 

### Description
- Added helper ` _summarize_empty_state_message` in `src/cli.py` to build a friendly empty-state hint. 
- Updated `cmd_summarize` in `src/cli.py` to log the empty-state warning and return `0` early if the parsed papers list is empty. 
- Extended `tests/test_cli.py` to include `TestSummarizeEmptyStateMessage` and a new test `test_returns_0_with_empty_input_list` that ensures the command returns success and that `SummarizerAgent` is not invoked for empty input. 

### Testing
- Ran the unit tests in `tests/test_cli.py` which include the new empty-state message and empty-input behavior tests. 
- All tests in `tests/test_cli.py` passed, including the new assertions that `SummarizerAgent` is not called for an empty papers list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e5933748832f9662c82863c7e81a)